### PR TITLE
Added maintenance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Other
 
+- Added maintenance mode for antidote. Directs to a static page hosted on GCP bucket. [#144](https://github.com/nre-learning/antidote/pull/144)
 - Added new image `utility-vm`, which provides a VM for the few lessons that require it (i.e. Docker) [#142](https://github.com/nre-learning/antidote/pull/142)
 
 ## 0.1.3 - November 15, 2018

--- a/infrastructure/dns.tf
+++ b/infrastructure/dns.tf
@@ -26,6 +26,17 @@ resource "google_dns_record_set" "ptr" {
   ]
 }
 
+resource "google_dns_record_set" "bypassmaint" {
+  name = "maintbypass.labs.networkreliability.engineering."
+  type = "A"
+  ttl  = 300
+  project = "${var.project}"
+  managed_zone = "nre"
+  rrdatas = [
+    "${google_compute_global_address.nrefrontend.address}",
+  ]
+}
+
 resource "google_dns_record_set" "abathur" {
   name = "abathur.networkreliability.engineering."
   type = "A"

--- a/infrastructure/lb.tf
+++ b/infrastructure/lb.tf
@@ -35,23 +35,43 @@ resource "google_compute_target_http_proxy" "nrehttpproxy" {
 resource "google_compute_url_map" "https-url-map" {
   name    = "https-url-map"
   project = "${var.project}"
+ 
+  host_rule {
+    hosts        = [
+      "labs.networkreliability.engineering",
+      "ptr.labs.networkreliability.engineering"
+    ]
+
+    path_matcher = "${var.prodstate}"
+  }
 
   host_rule {
-    hosts        = ["networkreliability.engineering"]
-    path_matcher = "allpaths"
+    hosts        = [
+      "maintbypass.labs.networkreliability.engineering"
+    ]
+    path_matcher = "production"
+  }
+
+  # Terraform throws an error if we don't use all path_matchers, so let's use
+  # this dummy domain to reference the maintenance path_matcher when it's not being used.
+  host_rule {
+    hosts        = [
+      "maint.labs.networkreliability.engineering"
+    ]
+    path_matcher = "maintenance"
   }
 
   path_matcher {
-    name            = "allpaths"
+    name            = "production"
     default_service = "${google_compute_backend_service.httpsbackend.self_link}"
-
-    path_rule {
-      paths   = ["/*"]
-      service = "${google_compute_backend_service.httpsbackend.self_link}"
-    }
   }
 
-  default_service = "${google_compute_backend_service.httpsbackend.self_link}"
+  path_matcher {
+    name            = "maintenance"
+    default_service = "${google_compute_backend_bucket.maintenance.self_link}"
+  }
+
+  default_service = "${google_compute_backend_bucket.maintenance.self_link}"
 }
 
 resource "google_compute_url_map" "http-url-map" {
@@ -59,21 +79,42 @@ resource "google_compute_url_map" "http-url-map" {
   project = "${var.project}"
 
   host_rule {
-    hosts        = ["networkreliability.engineering"]
-    path_matcher = "allpaths"
+    hosts        = [
+      "labs.networkreliability.engineering",
+      "ptr.labs.networkreliability.engineering"
+    ]
+
+    path_matcher = "${var.prodstate}"
+  }
+
+  host_rule {
+    hosts        = [
+      "maintbypass.labs.networkreliability.engineering"
+    ]
+    path_matcher = "production"
+  }
+
+
+  # Terraform throws an error if we don't use all path_matchers, so let's use
+  # this dummy domain to reference the maintenance path_matcher when it's not being used.
+  host_rule {
+    hosts        = [
+      "maint.labs.networkreliability.engineering"
+    ]
+    path_matcher = "maintenance"
   }
 
   path_matcher {
-    name            = "allpaths"
+    name            = "production"
     default_service = "${google_compute_backend_service.httpbackend.self_link}"
-
-    path_rule {
-      paths   = ["/*"]
-      service = "${google_compute_backend_service.httpbackend.self_link}"
-    }
   }
 
-  default_service = "${google_compute_backend_service.httpbackend.self_link}"
+  path_matcher {
+    name            = "maintenance"
+    default_service = "${google_compute_backend_bucket.maintenance.self_link}"
+  }
+
+  default_service = "${google_compute_backend_bucket.maintenance.self_link}"
 }
 
 resource "google_compute_backend_service" "httpsbackend" {
@@ -147,6 +188,13 @@ resource "google_compute_health_check" "httpshealth" {
   tcp_health_check {
     port = "30002"
   }
+}
+
+resource "google_compute_backend_bucket" "maintenance" {
+  name        = "maintenance"
+  project = "${var.project}"
+  bucket_name = "${google_storage_bucket.maintenance-page.name}"
+  enable_cdn  = true
 }
 
 
@@ -295,7 +343,6 @@ resource "google_compute_forwarding_rule" "k8sapi" {
   ports                 = ["6443"]
   load_balancing_scheme = "INTERNAL"
   backend_service       = "${google_compute_region_backend_service.k8sapi.self_link}"
-  service_label         = "k8sapi"
   network               = "${google_compute_network.default-internal.name}"
 }
 

--- a/infrastructure/maintenance_page/index.html
+++ b/infrastructure/maintenance_page/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>Site Maintenance</title>
+<style>
+  body { text-align: center; padding: 150px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+</style>
+
+<article>
+    <h1>Offline for Maintenance</h1>
+    <div>
+        <p>We're taking NRE Labs offline for a little bit to do some maintenance. Don't worry - we'll be back soon!
+
+           Follow <a href="https://twitter.com/NRElabs">@NRELabs</a> for the latest updates on all maintenance activities.</p>
+        <p>&mdash; The NRE Labs Team</p>
+    </div>
+</article>

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -1,0 +1,22 @@
+resource "google_storage_bucket" "maintenance-page" {
+  name     = "maintenance-page"
+  location = "US"
+
+  project   = "${var.project}"
+
+  website {
+    main_page_suffix = "index.html"
+  }
+}
+
+resource "google_storage_bucket_object" "index" {
+  name   = "index.html"
+  source = "./maintenance_page/index.html"
+  bucket = "${google_storage_bucket.maintenance-page.name}"
+}
+
+resource "google_storage_object_acl" "maintenance-acl" {
+  bucket = "${google_storage_bucket.maintenance-page.name}"
+  object = "${google_storage_bucket_object.index.name}"
+  predefined_acl = "publicRead"
+}

--- a/infrastructure/vars.tf
+++ b/infrastructure/vars.tf
@@ -1,3 +1,12 @@
+variable "prodstate" {
+
+  # This variable controlls the "production state" for antidote.
+  #
+  # Setting to "maintenance" will direct traffic to a static page hosted in a public read-only bucket instructing users of the downtime.
+  # Setting to "production" will direct traffic to the appropriate HTTP(s) backend service to the Antidote platform.
+  default = "production"
+}
+
 variable "zone" {
   default = "us-west1-a" # Oregon
 }

--- a/platform/prod/antidote-web.yaml
+++ b/platform/prod/antidote-web.yaml
@@ -77,9 +77,17 @@ spec:
   tls:
     - hosts:
       - labs.networkreliability.engineering
+      - maintbypass.labs.networkreliability.engineering
       secretName: tls-certificate
   rules:
   - host: labs.networkreliability.engineering
+    http:
+      paths:
+      - path: "/"
+        backend:
+          serviceName: antidote-web
+          servicePort: 8080
+  - host: maintbypass.labs.networkreliability.engineering
     http:
       paths:
       - path: "/"

--- a/platform/prod/syringe.yml
+++ b/platform/prod/syringe.yml
@@ -191,9 +191,17 @@ spec:
   tls:
     - hosts:
       - labs.networkreliability.engineering
+      - maintbypass.labs.networkreliability.engineering
       secretName: tls-certificate
   rules:
   - host: labs.networkreliability.engineering
+    http:
+      paths:
+      - path: "/syringe"
+        backend:
+          serviceName: syringe
+          servicePort: 8086
+  - host: maintbypass.labs.networkreliability.engineering
     http:
       paths:
       - path: "/syringe"


### PR DESCRIPTION
Managed to get this done purely through terraform, and using static pages served by a public GCP bucket. Modify `prodstate` in `vars.tf` to set maintenance mode, and re-run `terraform apply`

Closes https://github.com/nre-learning/antidote/issues/139