### PR TITLE
Removed lab guide URL from lesson definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Other
 
 - Simplified authentication by using consistent credentials, statically [#143](https://github.com/nre-learning/antidote/pull/143)
+- Remove lab guide from lesson definitions [#146](https://github.com/nre-learning/antidote/pull/146)
 
 ## 0.1.4 - January 08, 2019
 

--- a/lessons/lesson-12/syringe.yaml
+++ b/lessons/lesson-12/syringe.yaml
@@ -35,8 +35,6 @@ connections:
 stages:
   - id: 1
     description: No BGP config - tests fail
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-12/stage1/guide.md
 
   - id: 2
     description: Correct BGP config - tests pass
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-12/stage2/guide.md

--- a/lessons/lesson-13/syringe.yaml
+++ b/lessons/lesson-13/syringe.yaml
@@ -44,4 +44,3 @@ connections:
 stages:
   - id: 1
     description: Get device facts
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-13/stage1/guide.md

--- a/lessons/lesson-14/syringe.yaml
+++ b/lessons/lesson-14/syringe.yaml
@@ -11,10 +11,7 @@ utilities:
 stages:
   - id: 1
     description: Lists
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-14/stage1/guide.md
   - id: 2
     description: Dictionaries (key/value pairs)
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-14/stage2/guide.md
   # 3:
   #   description: What about JSON?
-  #   labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-14/stage3/guide.md

--- a/lessons/lesson-16/syringe.yaml
+++ b/lessons/lesson-16/syringe.yaml
@@ -13,16 +13,11 @@ utilities:
 stages:
   - id: 1
     description: Introduction
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-16/stage1/guide.md
   - id: 2
     description: For Loops
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-16/stage2/guide.md
   - id: 3
     description: '"If" and "Set" Statements'
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-16/stage3/guide.md
   - id: 4
     description: Passing Data into a Template From YAML
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-16/stage4/guide.md
   - id: 5
     description: Importing a Jinja Template from a File
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-16/stage5/guide.md

--- a/lessons/lesson-17/syringe.yaml
+++ b/lessons/lesson-17/syringe.yaml
@@ -11,7 +11,6 @@ utilities:
 stages:
   - id: 1
     description: Your first commit
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-17/stage1/guide.md
 
   # 2:
   #   What about Github? (a.k.a. Git remotes)

--- a/lessons/lesson-18/syringe.yaml
+++ b/lessons/lesson-18/syringe.yaml
@@ -25,4 +25,3 @@ connections:
 stages:
   - id: 1
     description: ToDD Basics
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-18/stage1/guide.md

--- a/lessons/lesson-19/syringe.yaml
+++ b/lessons/lesson-19/syringe.yaml
@@ -37,11 +37,8 @@ connections:
 stages:
   - id: 1
     description: Your First API Call
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-19/stage1/guide.md
 
   - id: 2
     description: Let's do it with Python!
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-19/stage2/guide.md
   # 3:
   #   description: Diving Deep into an API
-  #   labguide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-19/stage3/guide.md

--- a/lessons/lesson-20/syringe.yaml
+++ b/lessons/lesson-20/syringe.yaml
@@ -11,4 +11,3 @@ devices:
 stages:
   - id: 1
     description: Your First Config Commit
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-19/stage1/guide.md

--- a/lessons/lesson-21/syringe.yaml
+++ b/lessons/lesson-21/syringe.yaml
@@ -52,4 +52,3 @@ connections:
 stages:
   - id: 1
     description: Get the IP Address for a Phone Extension
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-21/stage1/guide.md

--- a/lessons/lesson-22/syringe.yaml
+++ b/lessons/lesson-22/syringe.yaml
@@ -12,12 +12,9 @@ utilities:
 stages:
   - id: 1
     description: Running Python for the First Time
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-22/stage1/guide.md
 
   - id: 2
     description: Basic Python Data Types
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-22/stage2/guide.md
 
   - id: 3
     description: Making Python Code More Re-usable
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-22/stage3/guide.md

--- a/lessons/lesson-23/syringe.yaml
+++ b/lessons/lesson-23/syringe.yaml
@@ -11,4 +11,3 @@ utilities:
 stages:
   - id: 1
     description: Using the Bash Shell
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-23/stage1/guide.md

--- a/lessons/lesson-24/syringe.yaml
+++ b/lessons/lesson-24/syringe.yaml
@@ -21,20 +21,15 @@ connections:
 stages:
   - id: 1
     description: Introduction
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-24/stage1/guide.md
 
   - id: 2
     description: Collect Data from Junos Devices
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-24/stage2/guide.md
 
   - id: 3
     description: Parse Information
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-24/stage3/guide.md
 
   - id: 4
     description: Configuration Management
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-24/stage4/guide.md
 
   - id: 5
     description: PyEZ Tables and Views
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-24/stage5/guide.md

--- a/lessons/lesson-29/syringe.yaml
+++ b/lessons/lesson-29/syringe.yaml
@@ -23,12 +23,9 @@ connections:
 stages:
   - id: 1
     description: Introduction to Robot Framework
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-29/stage1/guide.md
 
   - id: 2
     description: Writing Testcases for Junos Devices
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-29/stage2/guide.md
 
   - id: 3
     description: Robot Framework - Best Practices
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-29/stage3/guide.md

--- a/lessons/lesson-30/syringe.yaml
+++ b/lessons/lesson-30/syringe.yaml
@@ -23,12 +23,9 @@ connections:
 stages:
   - id: 1
     description: Salt Master and Minion
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-30/stage1/guide.md
 
   - id: 2
     description: Junos Proxy Minions
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-30/stage2/guide.md
 
   - id: 3
     description: Executing Junos commands in Salt
-    labGuide: https://raw.githubusercontent.com/nre-learning/antidote/master/lessons/lesson-30/stage3/guide.md


### PR DESCRIPTION
https://github.com/nre-learning/syringe/pull/41 introduced the ability to serve the lab guide content directly via the Syringe API, so we don't need these URLs anymore.