### PR TITLE
New vqfx image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Simplified authentication by using consistent credentials, statically [#143](https://github.com/nre-learning/antidote/pull/143)
 - Remove lab guide from lesson definitions [#146](https://github.com/nre-learning/antidote/pull/146)
+- Cleaned up and enabled LLDP within the `vqfx` image [#147](https://github.com/nre-learning/antidote/pull/147)
 
 ## 0.1.4 - January 08, 2019
 

--- a/images/vqfx/Dockerfile
+++ b/images/vqfx/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:stable
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    tcpdump \
+    htop \
+    socat \
+    screen \
+    qemu-kvm \
+    telnet \
+    vim \
+    procps \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY vqfx-orig.qcow2 /vqfx.qcow2
+COPY launch.sh /
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+ENTRYPOINT ["/launch.sh"]
+

--- a/images/vqfx/Dockerfile-snap1
+++ b/images/vqfx/Dockerfile-snap1
@@ -1,0 +1,25 @@
+FROM debian:stable
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    tcpdump \
+    htop \
+    socat \
+    screen \
+    qemu-kvm \
+    telnet \
+    vim \
+    procps \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY vqfx-snap1.qcow2 /vqfx.qcow2
+COPY launch.sh /
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+ENTRYPOINT ["/launch.sh"]

--- a/images/vqfx/Dockerfile-snap2
+++ b/images/vqfx/Dockerfile-snap2
@@ -1,0 +1,25 @@
+FROM debian:stable
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    tcpdump \
+    htop \
+    socat \
+    screen \
+    qemu-kvm \
+    telnet \
+    vim \
+    procps \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY vqfx-snap2.qcow2 /vqfx.qcow2
+COPY launch.sh /
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+ENTRYPOINT ["/launch.sh"]

--- a/images/vqfx/Dockerfile-snap3
+++ b/images/vqfx/Dockerfile-snap3
@@ -1,0 +1,25 @@
+FROM debian:stable
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy \
+ && apt-get upgrade -qy \
+ && apt-get install -y \
+    bridge-utils \
+    iproute2 \
+    python3-ipy \
+    tcpdump \
+    htop \
+    socat \
+    screen \
+    qemu-kvm \
+    telnet \
+    vim \
+    procps \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY vqfx-snap3.qcow2 /vqfx.qcow2
+COPY launch.sh /
+
+EXPOSE 22 161/udp 830 5000 10000-10099
+ENTRYPOINT ["/launch.sh"]

--- a/images/vqfx/README.md
+++ b/images/vqfx/README.md
@@ -1,0 +1,113 @@
+I created an "orig" image here, and I'm careful not to overwrite it when I'm copying the snapshotted qcow2 out of the container
+
+```
+qemu-img convert -f vmdk -O qcow2 ~/Code/Juniper/vrnetlab/vqfx/vqfx10k-re-15.1X53-D60.vmdk vqfx-orig.qcow2
+```
+
+
+
+
+qemu-system-x86_64 \
+ -display \
+ none \
+ -machine \
+ pc \
+ -monitor \
+ tcp:0.0.0.0:4000,server,nowait \
+ -m \
+ 2048 \
+ -serial \
+ telnet:0.0.0.0:5000,server,nowait \
+ -drive \
+ if=ide,file=/vqfx.qcow2,index=0 \
+ -device \
+ pci-bridge,chassis_nr=1,id=pci.1 \
+ -device \
+ e1000,netdev=p00,mac=$(random_mac) \
+ -netdev \
+ user,id=p00,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=tcp::2022-10.0.0.15:22,hostfwd=udp::2161-10.0.0.15:161,hostfwd=tcp::2830-10.0.0.15:830,hostfwd=tcp::2880-10.0.0.15:8080 \
+ -device \
+ e1000,netdev=vcp-int,mac=$(random_mac) \
+ -netdev \
+ tap,ifname=vcp-int,id=vcp-int,script=no,downscript=no \
+ -device \
+ e1000,netdev=dummy0,mac=$(random_mac) \
+ -netdev \
+ tap,ifname=dummy0,id=dummy0,script=no,downscript=no \
+ -device \
+ e1000,netdev=p01,mac=$(random_mac),bus=pci.1,addr=0x2 \
+ -netdev \
+ tap,id=p01,ifname=tap0,script=no,downscript=no \
+ -device \
+ e1000,netdev=p02,mac=$(random_mac),bus=pci.1,addr=0x3 \
+ -netdev \
+ tap,id=p02,ifname=tap1,script=no,downscript=no \
+ -device \
+ e1000,netdev=p03,mac=$(random_mac),bus=pci.1,addr=0x4 \
+ -netdev \
+ tap,id=p03,ifname=tap2,script=no,downscript=no \
+ -device \
+ e1000,netdev=p04,mac=$(random_mac),bus=pci.1,addr=0x5 \
+ -netdev \
+ tap,id=p04,ifname=tap3,script=no,downscript=no \
+ -device \
+ e1000,netdev=p05,mac=$(random_mac),bus=pci.1,addr=0x6 \
+ -netdev \
+ tap,id=p05,ifname=tap4,script=no,downscript=no \
+ -device \
+ e1000,netdev=p06,mac=$(random_mac),bus=pci.1,addr=0x7 \
+ -netdev \
+ tap,id=p06,ifname=tap5,script=no,downscript=no \
+ -device \
+ e1000,netdev=p07,mac=$(random_mac),bus=pci.1,addr=0x8 \
+ -netdev \
+ tap,id=p07,ifname=tap6,script=no,downscript=no \
+ -device \
+ e1000,netdev=p08,mac=$(random_mac),bus=pci.1,addr=0x9 \
+ -netdev \
+ tap,id=p08,ifname=tap7,script=no,downscript=no
+
+
+
+
+
+root
+Juniper
+
+clear
+cli
+configure
+    
+set system services ssh
+set system services netconf ssh
+set system services netconf rfc-compliant
+delete system login user vagrant
+set system login password change-type set-transitions minimum-changes 0
+commit
+
+set system login user antidote class super-user authentication plain-text-password
+
+antidotepassword
+
+set system root-authentication plain-text-password
+
+antidotepassword
+
+delete interfaces
+set interfaces em0 unit 0 family inet address 10.0.0.15/24
+set interfaces em1 unit 0 family inet address 169.254.0.2/24
+
+commit
+
+
+https://github.com/GNS3/gns3-gui/issues/725
+(qemu) stop
+
+(or system_powerdown - "stop" actually suspends)
+
+(qemu) savevm speedy
+
+
+(qemu) q
+
+qemu-img snapshot -l vqfx.qcow2

--- a/images/vqfx/launch.sh
+++ b/images/vqfx/launch.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+mount -o rw,remount /sys
+
+COUNTER=0
+while [  $COUNTER -lt 10 ]; do
+
+    let COUNTER1=COUNTER+1
+
+    net="net$COUNTER1"
+    tap="tap$COUNTER"
+    bridge=br$net$tap
+
+    ip link add $bridge type bridge
+    ip addr flush dev $net
+    ip link set $net master $bridge
+    ip tuntap add dev $tap mode tap
+    ip link set $tap master $bridge
+    ip link set $bridge up
+    ip link set $tap up
+
+    # Enable LLDP
+    echo 16384 > /sys/class/net/$bridge/bridge/group_fwd_mask
+
+    let COUNTER=COUNTER+1 
+done
+
+
+screen -d -m socat TCP-LISTEN:22,fork TCP:127.0.0.1:2022
+screen -d -m socat UDP-LISTEN:161,fork UDP:127.0.0.1:2161
+screen -d -m socat TCP-LISTEN:830,fork TCP:127.0.0.1:2830
+screen -d -m socat TCP-LISTEN:8080,fork TCP:127.0.0.1:2880
+
+random_mac () {
+    hexchars="0123456789abcdef"
+    end=$( for i in {1..6} ; do echo -n ${hexchars:$(( $RANDOM % 16 )):1} ; done | sed -e 's/\(..\)/:\1/g' )
+
+    # QEMU OUI space - important to use this
+    echo 52:54:00$end
+}
+
+# after ide
+
+
+#  --enable-kvm \
+
+# when on gcloud
+# echo 16384 | sudo tee -a /sys/class/net/12-jjtigg867g/bridge/group_fwd_mask
+
+# tcpdump -i net1 ether proto 0x88cc
+
+/usr/bin/qemu-system-x86_64 \
+ -display \
+ none \
+ -machine \
+ pc \
+ -monitor \
+ tcp:0.0.0.0:4000,server,nowait \
+ -m \
+ 2048 \
+ -serial \
+ telnet:0.0.0.0:5000,server,nowait \
+ -drive \
+ if=ide,file=/vqfx.qcow2,index=0 \
+ -loadvm speedy \
+ -device \
+ pci-bridge,chassis_nr=1,id=pci.1 \
+ -device \
+ e1000,netdev=p00,mac=$(random_mac) \
+ -netdev \
+ user,id=p00,net=10.0.0.0/24,tftp=/tftpboot,hostfwd=tcp::2022-10.0.0.15:22,hostfwd=udp::2161-10.0.0.15:161,hostfwd=tcp::2830-10.0.0.15:830,hostfwd=tcp::2880-10.0.0.15:8080 \
+ -device \
+ e1000,netdev=vcp-int,mac=$(random_mac) \
+ -netdev \
+ tap,ifname=vcp-int,id=vcp-int,script=no,downscript=no \
+ -device \
+ e1000,netdev=dummy0,mac=$(random_mac) \
+ -netdev \
+ tap,ifname=dummy0,id=dummy0,script=no,downscript=no \
+ -device \
+ e1000,netdev=p01,mac=$(random_mac),bus=pci.1,addr=0x2 \
+ -netdev \
+ tap,id=p01,ifname=tap0,script=no,downscript=no \
+ -device \
+ e1000,netdev=p02,mac=$(random_mac),bus=pci.1,addr=0x3 \
+ -netdev \
+ tap,id=p02,ifname=tap1,script=no,downscript=no \
+ -device \
+ e1000,netdev=p03,mac=$(random_mac),bus=pci.1,addr=0x4 \
+ -netdev \
+ tap,id=p03,ifname=tap2,script=no,downscript=no \
+ -device \
+ e1000,netdev=p04,mac=$(random_mac),bus=pci.1,addr=0x5 \
+ -netdev \
+ tap,id=p04,ifname=tap3,script=no,downscript=no \
+ -device \
+ e1000,netdev=p05,mac=$(random_mac),bus=pci.1,addr=0x6 \
+ -netdev \
+ tap,id=p05,ifname=tap4,script=no,downscript=no \
+ -device \
+ e1000,netdev=p06,mac=$(random_mac),bus=pci.1,addr=0x7 \
+ -netdev \
+ tap,id=p06,ifname=tap5,script=no,downscript=no \
+ -device \
+ e1000,netdev=p07,mac=$(random_mac),bus=pci.1,addr=0x8 \
+ -netdev \
+ tap,id=p07,ifname=tap6,script=no,downscript=no \
+ -device \
+ e1000,netdev=p08,mac=$(random_mac),bus=pci.1,addr=0x9 \
+ -netdev \
+ tap,id=p08,ifname=tap7,script=no,downscript=no
+
+
+
+
+
+
+
+sleep 100000

--- a/images/vqfx/push.sh
+++ b/images/vqfx/push.sh
@@ -1,0 +1,12 @@
+# docker build -f Dockerfile -t antidotelabs/vqfx .
+
+# docker run -p 2202:22 --privileged --rm --name vqfx -v /Users/mierdin/Code/GO/src/github.com/nre-learning/antidote/images/vqfx:/dockervolume antidotelabs/vqfx
+
+# docker push antidotelabs/vqfx
+
+
+docker build -f Dockerfile-snap1 -t antidotelabs/vqfx:snap1 .
+docker build -f Dockerfile-snap2 -t antidotelabs/vqfx:snap2 .
+docker build -f Dockerfile-snap3 -t antidotelabs/vqfx:snap3 .
+
+docker push antidotelabs/vqfx


### PR DESCRIPTION
https://github.com/nre-learning/antidote/pull/143 switched the lessons over to this new image; this PR introduces the code that makes it work.

It's mostly the same as the old image, but has changes to allow for LLDP. It's also a better name. Keeping both for now for posterity, though `vqfxspeedy` will be deprecated later. Ideally, we can get rid of the three snapshots too, and just have one that we can truly randomize MAC addresses for. However, this will suffice for now.