### PR TITLE
Clarify internet access restrictions in REST API lesson and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Curriculum
 
+- Clarify internet access restrictions in REST API lesson and docs [#148](https://github.com/nre-learning/antidote/pull/148)
+
 ### Other
 
 - Simplified authentication by using consistent credentials, statically [#143](https://github.com/nre-learning/antidote/pull/143)

--- a/docs/contributing/curriculum.rst
+++ b/docs/contributing/curriculum.rst
@@ -64,6 +64,11 @@ leveraged to build a lesson.  Consider using open-source tools for the lessons,
 or tools that are at least free.  This helps ensure that a user could more
 easily replicate what is shown in the lesson.
 
+.. note::
+    For security reasons, internet access will not be enabled for labs hosted within :ref:`NRE Labs <nrelabs>`.
+    All lessons should be totally self-contained and not rely on external resources to properly function
+    when the lesson is being run.
+
 Step 3 - Put It Together
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lessons/lesson-19/stage1/guide.md
+++ b/lessons/lesson-19/stage1/guide.md
@@ -15,7 +15,9 @@ In this lesson we'll start actually working with REST APIs, so we can better und
 
 For this exercise, we'll be working with the [Junos REST API](https://www.juniper.net/documentation/en_US/junos/topics/concept/rest-api-overview.html), but it should be noted that nearly every network operating system these days has their own REST API. The kind of information you have to put into them, as well as what you get out of them, won't all be the same, but they'll follow the same general ideas we'll explore here.
 
-If you've ever worked on a Linux system, or maybe an Apple computer, you might have run into a command called `curl`. This is a simple tool for fetching the contents of a web page. A simple example would be to request the front page of `google.com`:
+If you've ever worked on a Linux system, or maybe an Apple computer, you might have run into a command called `curl`. This is a simple tool for fetching the contents of a web page. A simple example would be to request the front page of `google.com`.
+
+**NOTE**: For security purposes, we don't allow access to the internet from our lesson, and as a result, the following command won't actually work. Don't worry though, we have other resources in this lesson you can query.
 
 ```
 curl https://google.com
@@ -28,7 +30,7 @@ What if, instead, we were to query a resource somewhere that wasn't even intende
 
 ```
 curl \
-    -u "root:VR-netlab9" \
+    -u "antidote:antidotepassword" \
     http://vqfx1:8080/rpc/get-interface-information \
     --header "Accept: application/json"
 ```

--- a/lessons/lesson-19/stage2/guide.md
+++ b/lessons/lesson-19/stage2/guide.md
@@ -25,7 +25,7 @@ The best Python library to query a REST API is `requests`. In the following snip
 ```
 import requests
 headers = {'Accept': 'application/json'}
-resp = requests.get('http://vqfx1:8080/rpc/get-interface-information', headers=headers, auth=('root', 'VR-netlab9'))
+resp = requests.get('http://vqfx1:8080/rpc/get-interface-information', headers=headers, auth=('antidote', 'antidotepassword'))
 ```
 <button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('linux1', 1)">Run this snippet</button>
 


### PR DESCRIPTION
- Update credentials in REST API lesson, and briefly clarify that internet requests won't work (and why)
- Update docs to explain this further.

Closes https://github.com/nre-learning/antidote/issues/104