### PR TITLE
Finish enabling LLDP

### DIFF
--- a/lessons/lesson-12/stage1/configs/vqfx1.txt
+++ b/lessons/lesson-12/stage1/configs/vqfx1.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-12/stage1/configs/vqfx2.txt
+++ b/lessons/lesson-12/stage1/configs/vqfx2.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-12/stage1/configs/vqfx3.txt
+++ b/lessons/lesson-12/stage1/configs/vqfx3.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-12/stage2/configs/vqfx1.txt
+++ b/lessons/lesson-12/stage2/configs/vqfx1.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-12/stage2/configs/vqfx2.txt
+++ b/lessons/lesson-12/stage2/configs/vqfx2.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-12/stage2/configs/vqfx3.txt
+++ b/lessons/lesson-12/stage2/configs/vqfx3.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-13/stage1/configs/vqfx1.txt
+++ b/lessons/lesson-13/stage1/configs/vqfx1.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-13/stage1/configs/vqfx2.txt
+++ b/lessons/lesson-13/stage1/configs/vqfx2.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-13/stage1/configs/vqfx3.txt
+++ b/lessons/lesson-13/stage1/configs/vqfx3.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-18/stage1/configs/vqfx1.txt
+++ b/lessons/lesson-18/stage1/configs/vqfx1.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage1/configs/vqfx1.txt
+++ b/lessons/lesson-19/stage1/configs/vqfx1.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage1/configs/vqfx2.txt
+++ b/lessons/lesson-19/stage1/configs/vqfx2.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage1/configs/vqfx3.txt
+++ b/lessons/lesson-19/stage1/configs/vqfx3.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage2/configs/vqfx1.txt
+++ b/lessons/lesson-19/stage2/configs/vqfx1.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage2/configs/vqfx2.txt
+++ b/lessons/lesson-19/stage2/configs/vqfx2.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage2/configs/vqfx3.txt
+++ b/lessons/lesson-19/stage2/configs/vqfx3.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage3/configs/vqfx1.txt
+++ b/lessons/lesson-19/stage3/configs/vqfx1.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage3/configs/vqfx2.txt
+++ b/lessons/lesson-19/stage3/configs/vqfx2.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-19/stage3/configs/vqfx3.txt
+++ b/lessons/lesson-19/stage3/configs/vqfx3.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-22/stage1/configs/vqfx1.txt
+++ b/lessons/lesson-22/stage1/configs/vqfx1.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-22/stage1/configs/vqfx2.txt
+++ b/lessons/lesson-22/stage1/configs/vqfx2.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-22/stage1/configs/vqfx3.txt
+++ b/lessons/lesson-22/stage1/configs/vqfx3.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-24/stage1/configs/vqfx.txt
+++ b/lessons/lesson-24/stage1/configs/vqfx.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-24/stage2/configs/vqfx.txt
+++ b/lessons/lesson-24/stage2/configs/vqfx.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-24/stage3/configs/vqfx.txt
+++ b/lessons/lesson-24/stage3/configs/vqfx.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-24/stage4/configs/vqfx.txt
+++ b/lessons/lesson-24/stage4/configs/vqfx.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-24/stage5/configs/vqfx.txt
+++ b/lessons/lesson-24/stage5/configs/vqfx.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-29/stage1/configs/vqfx1.txt
+++ b/lessons/lesson-29/stage1/configs/vqfx1.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-29/stage2/configs/vqfx1.txt
+++ b/lessons/lesson-29/stage2/configs/vqfx1.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-29/stage3/configs/vqfx1.txt
+++ b/lessons/lesson-29/stage3/configs/vqfx1.txt
@@ -140,6 +140,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-30/stage1/configs/vqfx1.txt
+++ b/lessons/lesson-30/stage1/configs/vqfx1.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-30/stage2/configs/vqfx1.txt
+++ b/lessons/lesson-30/stage2/configs/vqfx1.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>

--- a/lessons/lesson-30/stage3/configs/vqfx1.txt
+++ b/lessons/lesson-30/stage3/configs/vqfx1.txt
@@ -154,6 +154,13 @@
                     <name>default</name>
                 </vlan>
             </igmp-snooping>
+            <lldp>
+                <advertisement-interval>5</advertisement-interval>
+                <hold-multiplier>2</hold-multiplier>
+                <interface>
+                    <name>all</name>
+                </interface>
+            </lldp>
         </protocols>
         <vlans>
             <vlan>


### PR DESCRIPTION
The introduction of the new `vqfx` image means that the bridges within the container allow LLDP. This PR finishes the tasks needed to enable LLDP within the solution by accomplishing the final two tasks:

- Add configuration for LLDP for all network devices
- Add custom `antibridge` CNI plugin download to the bootstrap playbooks. This is effectively the same as the `bridge` plugin, with minor adjustments to enable LLDP.

Closes https://github.com/nre-learning/antidote/issues/39