### PR TITLE
Moved to a custom githelper image for making lesson repo available in pods with correct permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Cleaned up and enabled LLDP within the `vqfx` image [#147](https://github.com/nre-learning/antidote/pull/147)
 - Enable LLDP end-to-end [#150](https://github.com/nre-learning/antidote/pull/150)
 - Added better docs for Syringe environment variables [#160](https://github.com/nre-learning/antidote/pull/160)
+- Moved to a custom githelper image for making lesson repo available in pods with correct permissions [#162](https://github.com/nre-learning/antidote/pull/162)
 
 ## 0.1.4 - January 08, 2019
 

--- a/images/githelper/Dockerfile
+++ b/images/githelper/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine/git
+COPY git-clone.sh /
+RUN adduser antidote -D
+
+ENTRYPOINT ["/git-clone.sh"]

--- a/images/githelper/git-clone.sh
+++ b/images/githelper/git-clone.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+REPO=$1
+REF=$2
+DIR=$3
+# Init Containers will re-run on Pod restart. Remove the directory's contents
+# and reprovision when this happens.
+if [ -d "$DIR" ]; then
+    rm -rf $( find $DIR -mindepth 1 )
+fi
+git clone $REPO $DIR
+cd $DIR
+# git reset --hard $REF
+git checkout $REF
+
+chown -R antidote:antidote $DIR

--- a/platform/prod/antidote-web.yaml
+++ b/platform/prod/antidote-web.yaml
@@ -20,7 +20,7 @@ spec:
         ports:
         - containerPort: 4822
       - name: antidote-web
-        image: antidotelabs/antidote-web:release-v0.1.4
+        image: antidotelabs/antidote-web:release-v0.1.4  #revme
         imagePullPolicy: Always
         env:
         - name: GUACD_HOSTNAME

--- a/platform/prod/syringe.yml
+++ b/platform/prod/syringe.yml
@@ -6,27 +6,6 @@ metadata:
   namespace: prod
 
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: git-clone
-  namespace: prod
-data:
-  git-clone.sh: |
-    #!/bin/sh -e
-    REPO=$1
-    REF=$2
-    DIR=$3
-    # Init Containers will re-run on Pod restart. Remove the directory's contents
-    # and reprovision when this happens.
-    if [ -d "$DIR" ]; then
-        rm -rf $( find $DIR -mindepth 1 )
-    fi
-    git clone $REPO $DIR
-    cd $DIR
-    git reset --hard $REF
-
----
 # TODO(mierdin): This could probably use some pruning
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -94,16 +73,12 @@ spec:
     spec:
       initContainers:
       - name: git-clone
-        image: alpine/git # Any image with git will do
-        command:
-        - /usr/local/git/git-clone.sh
+        image: antidotelabs/githelper
         args:
         - "https://github.com/nre-learning/antidote.git"
-        - "v0.1.4"
+        - "v0.1.4"  #revme
         - "/antidote"
         volumeMounts:
-        - name: git-clone
-          mountPath: /usr/local/git
         - name: git-volume  #?
           mountPath: /antidote
 
@@ -111,7 +86,7 @@ spec:
       serviceAccount: syringesa
       containers:
       - name: syringe
-        image: antidotelabs/syringe:release-v0.1.4
+        image: antidotelabs/syringe:release-v0.1.4  #revme
         imagePullPolicy: Always
         env:
         - name: SYRINGE_DOMAIN
@@ -123,11 +98,12 @@ spec:
         - name: SYRINGE_LESSON_REPO_REMOTE
           value: "https://github.com/nre-learning/antidote.git"
         - name: SYRINGE_LESSON_REPO_BRANCH
-          value: "v0.1.4"
+          value: "v0.1.4"  #revme
         - name: SYRINGE_LESSON_REPO_DIR
           value: "/antidote"
         ports:
-        - containerPort: 50099  # GRPC
+        # Only accessible from within the container
+        # - containerPort: 50099  # GRPC
         - containerPort: 8086   # REST/HTTP
         readinessProbe:
           httpGet:
@@ -139,10 +115,6 @@ spec:
       volumes:
         - name: git-volume
           emptyDir: {}
-        - name: git-clone
-          configMap:
-            name: git-clone
-            defaultMode: 0755
 
 # /var/run/secrets/kubernetes.io/serviceaccount
 
@@ -160,10 +132,11 @@ spec:
   selector:
     app: syringe
   ports:
-    - name: grpc
-      port: 50099
-      targetPort: 50099
-      # nodePort: 30010
+    # # Only accessible from within the container
+    # - name: grpc
+    #   port: 50099
+    #   targetPort: 50099
+    #   # nodePort: 30010
     - name: http
       port: 8086
       targetPort: 8086

--- a/platform/ptr/syringe.yml
+++ b/platform/ptr/syringe.yml
@@ -6,27 +6,6 @@ metadata:
   namespace: ptr
 
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: git-clone
-  namespace: ptr
-data:
-  git-clone.sh: |
-    #!/bin/sh -e
-    REPO=$1
-    REF=$2
-    DIR=$3
-    # Init Containers will re-run on Pod restart. Remove the directory's contents
-    # and reprovision when this happens.
-    if [ -d "$DIR" ]; then
-        rm -rf $( find $DIR -mindepth 1 )
-    fi
-    git clone $REPO $DIR
-    cd $DIR
-    git checkout --force $REF
-
----
 # TODO(mierdin): This could probably use some pruning
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -93,17 +72,13 @@ spec:
     spec:
       initContainers:
       - name: git-clone
-        image: alpine/git # Any image with git will do
-        command:
-        - /usr/local/git/git-clone.sh
+        image: antidotelabs/githelper
         args:
         - "https://github.com/nre-learning/antidote.git"
-        - "master"
+        - "st2-lesson"
         - "/antidote"
         volumeMounts:
-        - name: git-clone
-          mountPath: /usr/local/git
-        - name: git-volume  #?
+        - name: git-volume
           mountPath: /antidote
 
       # Might need an admission controller for this
@@ -122,11 +97,12 @@ spec:
         - name: SYRINGE_LESSON_REPO_REMOTE
           value: "https://github.com/nre-learning/antidote.git"
         - name: SYRINGE_LESSON_REPO_BRANCH
-          value: "master"
+          value: "st2-lesson"
         - name: SYRINGE_LESSON_REPO_DIR
           value: "/antidote"
         ports:
-        - containerPort: 50099  # GRPC
+        # Only accessible from within the container
+        # - containerPort: 50099  # GRPC
         - containerPort: 8086   # REST/HTTP
         readinessProbe:
           httpGet:
@@ -138,10 +114,7 @@ spec:
       volumes:
         - name: git-volume
           emptyDir: {}
-        - name: git-clone
-          configMap:
-            name: git-clone
-            defaultMode: 0755
+
 ---
 kind: Service
 apiVersion: v1
@@ -152,9 +125,10 @@ spec:
   selector:
     app: syringe
   ports:
-    - name: grpc
-      port: 50099
-      targetPort: 50099
+    # Only accessible from within the container
+    # - name: grpc
+    #   port: 50099
+    #   targetPort: 50099
     - name: http
       port: 8086
       targetPort: 8086


### PR DESCRIPTION
The lesson directory cloned into lesson endpoints was owned by `root:root`, and so the `antidote` user which is used for user logins couldn't change any of the files with their current permissions.

In addition, this approach caused Syringe to rely on a ConfigMap present in Kubernetes that it didn't control. Instead, this image contains the appropriate cloning logic built-in.