### PR TITLE
Fix target VM for one action in lesson 15 stage 2

### DIFF
--- a/lessons/lesson-15/stage2/guide.md
+++ b/lessons/lesson-15/stage2/guide.md
@@ -123,7 +123,7 @@ As part of this lesson, we've included a configuration snippet that will replace
 ```
 cat /antidote/lessons/lesson-15/stage2/vqfx1-config-patch.txt
 ```
-<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('vqfx1', 10)">Run this snippet</button>
+<button type="button" class="btn btn-primary btn-sm" onclick="runSnippetInTab('st2', 10)">Run this snippet</button>
 
 The `loadconfig` action can accept this path as a parameter, and will perform a merge between this configuration, and the existing configuration:
 


### PR DESCRIPTION
While following lesson 15, I noticed that 1 action is executed in the wrong VM(`vqfx1` instead of `st2`) in stage 2
```
cat /antidote/lessons/lesson-15/stage2/vqfx1-config-patch.txt
```
I think this PR will fix that
Great job on this lesson