### PR TITLE
Removed unneeded subnet declarations from connections list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Other
 
 - Added new community page, in place of the much lighter 'resources' page [#199](https://github.com/nre-learning/antidote/pull/199)
+- Removed unneeded subnet declarations from connections list [#200](https://github.com/nre-learning/antidote/pull/200)
 
 ## v0.3.0 - February 11, 2019
 

--- a/lessons/lesson-12/syringe.yaml
+++ b/lessons/lesson-12/syringe.yaml
@@ -30,13 +30,10 @@ devices:
 connections:
 - a: vqfx1
   b: vqfx2
-  subnet: 10.12.0.0/24
 - a: vqfx2
   b: vqfx3
-  subnet: 10.23.0.0/24
 - a: vqfx3
   b: vqfx1
-  subnet: 10.31.0.0/24
 
 stages:
   - id: 1

--- a/lessons/lesson-15/syringe.yaml
+++ b/lessons/lesson-15/syringe.yaml
@@ -43,13 +43,10 @@ devices:
 connections:
 - a: vqfx1
   b: vqfx2
-  subnet: 10.12.0.0/24
 - a: vqfx2
   b: vqfx3
-  subnet: 10.23.0.0/24
 - a: vqfx3
   b: vqfx1
-  subnet: 10.31.0.0/24
 
 stages:
   - id: 1

--- a/lessons/lesson-18/syringe.yaml
+++ b/lessons/lesson-18/syringe.yaml
@@ -24,10 +24,8 @@ devices:
 connections:
 - a: todd1
   b: vqfx1
-  subnet: 10.12.0.0/24
 - a: vqfx1
   b: web1
-  subnet: 10.23.0.0/24
 
 stages:
   - id: 1

--- a/lessons/lesson-19/syringe.yaml
+++ b/lessons/lesson-19/syringe.yaml
@@ -33,16 +33,12 @@ devices:
 connections:
 - a: vqfx1
   b: vqfx2
-  subnet: 10.12.0.0/24
 - a: vqfx2
   b: vqfx3
-  subnet: 10.23.0.0/24
 - a: vqfx3
   b: vqfx1
-  subnet: 10.31.0.0/24
 - a: vqfx1
   b: linux1
-  subnet: 10.1.0.0/24
 
 stages:
   - id: 1

--- a/lessons/lesson-21/syringe.yaml
+++ b/lessons/lesson-21/syringe.yaml
@@ -39,22 +39,16 @@ utilities:
 connections:
 - a: vqfx1
   b: vqfx2
-  subnet: 10.10.10.0/24
 - a: vqfx2
   b: vqfx3
-  subnet: 10.10.20.0/24
 - a: vqfx3
   b: vqfx1
-  subnet: 10.10.30.0/24
 - a: vqfx2
   b: sipphone
-  subnet: 10.10.150.0/24
 - a: vqfx1
   b: netbox
-  subnet: 10.10.100.0/24
 - a: vqfx1
   b: asterisk
-  subnet: 10.10.200.0/24
 
 
 stages:

--- a/lessons/lesson-24/syringe.yaml
+++ b/lessons/lesson-24/syringe.yaml
@@ -27,7 +27,6 @@ devices:
 connections:
 - a: vqfx
   b: linux
-  subnet: 10.1.0.0/24
 
 stages:
   - id: 1

--- a/lessons/lesson-29/syringe.yaml
+++ b/lessons/lesson-29/syringe.yaml
@@ -23,7 +23,6 @@ devices:
 connections:
 - a: vqfx1
   b: linux1
-  subnet: 10.1.0.0/24
 
 stages:
   - id: 1

--- a/lessons/lesson-30/syringe.yaml
+++ b/lessons/lesson-30/syringe.yaml
@@ -28,7 +28,6 @@ devices:
 connections:
 - a: vqfx1
   b: salt1
-  subnet: 10.1.0.0/24
 
 stages:
   - id: 1


### PR DESCRIPTION
https://github.com/nre-learning/syringe/pull/88 removed the need to specify a subnet in the connections list. This was never **really** needed - this was here to appease the CNI configuration, but clearly after months of running this, it's obvious that these subnets are not actually enforced - we've been able to use our own addressing on the devices that use these connections.

So, to simplify, we're removing the requirement to specify this in the lesson definition.