### PR TITLE
update config directory in docs

### DIFF
--- a/docs/hacking/curriculum.rst
+++ b/docs/hacking/curriculum.rst
@@ -56,7 +56,7 @@ Preparing the Environment
 -------------------------
 
 You can create a configuration file for selfmedicate, but it is not required.  It should be called "config"
-and located in directory "$HOME/.selfmedicate"  Not all variables need to be specified.  The following variables
+and located in directory "$HOME/.antidote/"  Not all variables need to be specified.  The following variables
 are supported::
 
     CPUS               - The number of CPUs minikube should run on.  (default: 2)


### PR DESCRIPTION
to match path hardcoded in selfmedicate.sh
See: [selfmedicate.sh file at master at line 12](https://github.com/nre-learning/antidote-selfmedicate/blob/master/selfmedicate.sh) 