### PR TITLE
Remove v0.34.1 notice - it's no longer relevant

### DIFF
--- a/docs/hacking/curriculum.rst
+++ b/docs/hacking/curriculum.rst
@@ -40,11 +40,6 @@ Next, you'll need minikube. This is by far the easiest way to get a working inst
 running on your laptop. Follow the `installation instructions <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_
 to install, but do not start minikube.  Make sure you install kubectl as well.  Instructions are on the same page.
 
-.. warning::
-
-    The currently supported version of minikube is v0.34.1. Please install this version specifically. You may
-    encounter issues with other versions.
-
 .. note:: 
 
     The ``selfmedicate`` script starts a minikube VM with 8GB of RAM and 4 vCPUs by default. While this isn't a strict


### PR DESCRIPTION
I have been running on a much more recent version of selfmedicate (1.2.0) for a while and haven't experienced any issues, so I think it's time to remove this from the docs.