### PR TITLE
New guides and standards for platform and curriculum

### DIFF
--- a/docs/contribute/curriculum.rst
+++ b/docs/contribute/curriculum.rst
@@ -123,22 +123,8 @@ the PR is merged, the referenced issue(s) will be closed automatically.
 At this point, the next step is for a reviewer to approve or make suggestions for a second round of edits
 for your content. Note that the goal for **each and every review** is not to nitpick or make it difficult to
 contribute to NRE Labs, but rather to ensure the content is reflected in the best light possible. Be patient
-and willing to adapt to feedback.
-
-Here are a few things that reviewers should be on the lookout for when reviewing new contributions to the
-curriculum, either for new or existing lessons. If you're contributing to the curriculum, you should be aware
-of these guidelines, to make the review process much smoother.
-
-- Can a user get through a lesson stage quickly? Are we letting them get to a quick win as soon as practical while still teaching quality content?
-- Does the new or changed lesson adhere to the spirit of Antidote lessons laid out in this document?
-- For new lessons, does the lesson guide (or jupyter notebook if applicable) look nice? Does the author attribute themselves?
-- Is the lesson guide(s) easy to follow?
-- Are any documentation updates also needed?
-- Is the CHANGELOG updated properly?
-- Can we show this in NRE labs? Usage rights?
-- Does this follow the :ref:`Lesson Image Requirements <lessonimages>`?
-- Is the business benefit clear from this lesson? How easy is it for people to link this content with their day-to-day?
-
+and willing to adapt to feedback. It might be useful to take a peek at the :ref:`curriculum review standards <curriculum-reviewers>` as that covers
+everything that a curriculum reviewer will be looking for.
 
 .. _contrib-othermaintainers:
 

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -14,6 +14,7 @@ Before starting your work, please read this section in its entirety, so your wor
    git.rst
    terminology.rst
    curriculum.rst
+   reviewer.rst
    platform.rst
    docs.rst
    nondev.rst

--- a/docs/contribute/platform.rst
+++ b/docs/contribute/platform.rst
@@ -65,3 +65,25 @@ something, but not so challenging that you have to spin your wheels for weeks be
 We've explicitly carved up Github issues in nearly every Antidote project repository just for you. Take a look at the :ref:`Git section
 of these docs <git-lowhanging>` where you'll find a system of labeling issues by complexity, so you can see at-a-glance which issues have
 been identified for the express purpose of getting started with the project.
+
+Going Big
+~~~~~~~~~
+
+For complex features, especially those that span across the various component projects to the Antidote platform,
+you'll be required to create a blueprint in the `proposals <https://github.com/nre-learning/proposals/tree/master/blueprints>`_
+repo. This gives needed structure for the effort you have in mind, and gives others a chance to get involved.
+
+There are no hard rules on when a blueprint is required, but please be prepared to do this if a maintainer asks
+in order to move things forward. There are also no rules on what should be *in* a blueprint, but it should minimally
+answer the following:
+
+- What is the problem you're trying to solve? How will this solve that problem?
+- What components of Antidote (and how) will this need to touch?
+- What is the detailed design of the feature in it's ultimate state?
+- What are the discrete steps (each step being its own PR) we will need to take to accomplish this feature. If
+  separate steps, how will we ensure project stability while the work is in progress?
+
+Blueprints aren't meant to be a super formal, heavy-handed process for everyone to go through before they can
+do anything - ideally they'll only be used for the really complicated ideas as the project moves out of the "alpha"
+stage, and will help keep everyone abreast of the big ideas and how the work will get done - providing space for
+everyone to contribute the way they want to.

--- a/docs/contribute/reviewer.rst
+++ b/docs/contribute/reviewer.rst
@@ -46,6 +46,7 @@ Technical
 - Does this follow the :ref:`Lesson Image Requirements <lessonimages>`?
 - Does the lesson appropriately take advantage of Antidote's optional features for content depth (like
   optional objective verification) or diverse presentations?
+- Do the configuration mechanisms in place for the Endpoints properly reverse/forward based on stage?
 
 Logistics
 ---------

--- a/docs/contribute/reviewer.rst
+++ b/docs/contribute/reviewer.rst
@@ -4,12 +4,14 @@ Curriculum Review Standards
 ===========================
 
 **ALL** contributions to the NRE Labs curriculum must be done via a Pull Request, and Pull Requests
-can only be merged to ``master`` if the latest commit:
+can only be merged to ``master`` if the latest commit on that Pull Request's branch satisfies all of
+these requirements:
 
 1. Passes all Github CI checks
 2. Has a valid "accepted" review from a curriculum committer that is different from the PR creator.
 
-At this point, the next step is for a reviewer to approve or make suggestions for a second round of edits
+These are meant to be done in order. There is no point in conducting a review until all Github CI checks pass.
+However, once these are passing, the next step is for a reviewer to approve or make suggestions for a second round of edits
 for your content. Note that the goal for **each and every review** is not to nitpick or make it difficult to
 contribute to NRE Labs, but rather to ensure the content is reflected in the best light possible. Be patient
 and willing to adapt to feedback.
@@ -27,29 +29,24 @@ missed any of the below, please open an issue on the curriculum repo.
 - Is the CHANGELOG updated properly?
 - Does ``syrctl validate`` pass?
 
-New Content Guidelines
-----------------------
+Content Quality
+---------------
 
-- Is the business benefit clear from this lesson? How easy is it for people
+Quality is important in NRE Labs. Here are some general things to be on the lookout for.
+
+- Is the relevance to the learner clear from this lesson? How easy is it for people
   to link this content with their day-to-day?
-- Can a user get through a lesson stage quickly? Are we letting them get to a
-  quick win as soon as practical while still teaching quality content?
-- Does the new or changed lesson adhere to the spirit of Antidote lessons
-  laid out in this document?
-- For new lessons, does the lesson guide (or jupyter notebook if
-  applicable) look nice? Does the author attribute themselves?
-- Is the lesson guide(s) easy to follow?
+- Does each lesson stage hit the target length of 5-10 minutes?
+- Are the lesson guides easy to follow? Are they well-written,
+  with appropriate chunking, puncuation/grammar, and visuals?
 
 Technical
 ---------
 
+It's also very important that the curriculum takes maximum advantage of the underlying Antidote
+platform.
+
 - Does this follow the :ref:`Lesson Image Requirements <lessonimages>`?
-- Does the lesson appropriately take advantage of Antidote's optional features for content depth (like
-  optional objective verification) or diverse presentations?
+- Does the lesson appropriately take advantage of Antidote's optional features for content depth, like
+  optional objective verification or diverse presentations? How about lesson diagrams or videos?
 - Do the configuration mechanisms in place for the Endpoints properly reverse/forward based on stage?
-
-Logistics
----------
-
-- Are any documentation updates also needed?
-- Can we show this in NRE labs? Usage rights?

--- a/docs/contribute/reviewer.rst
+++ b/docs/contribute/reviewer.rst
@@ -1,0 +1,54 @@
+.. _curriculum-reviewers:
+
+Curriculum Review Standards
+===========================
+
+**ALL** contributions to the NRE Labs curriculum must be done via a Pull Request, and Pull Requests
+can only be merged to ``master`` if the latest commit:
+
+1. Passes all Github CI checks
+2. Has a valid "accepted" review from a curriculum committer that is different from the PR creator.
+
+At this point, the next step is for a reviewer to approve or make suggestions for a second round of edits
+for your content. Note that the goal for **each and every review** is not to nitpick or make it difficult to
+contribute to NRE Labs, but rather to ensure the content is reflected in the best light possible. Be patient
+and willing to adapt to feedback.
+
+Here are a few things that reviewers should be on the lookout for when reviewing new contributions to the
+curriculum, either for new or existing lessons. If you're contributing to the curriculum, you should be aware
+of these guidelines, to make the review process much smoother.
+
+(Hopefully) Automated Checks
+----------------------------
+
+The following should be automatically checked via the CI tooling, but please double-check, and if the CI tooling
+missed any of the below, please open an issue on the curriculum repo.
+
+- Is the CHANGELOG updated properly?
+- Does ``syrctl validate`` pass?
+
+New Content Guidelines
+----------------------
+
+- Is the business benefit clear from this lesson? How easy is it for people
+  to link this content with their day-to-day?
+- Can a user get through a lesson stage quickly? Are we letting them get to a
+  quick win as soon as practical while still teaching quality content?
+- Does the new or changed lesson adhere to the spirit of Antidote lessons
+  laid out in this document?
+- For new lessons, does the lesson guide (or jupyter notebook if
+  applicable) look nice? Does the author attribute themselves?
+- Is the lesson guide(s) easy to follow?
+
+Technical
+---------
+
+- Does this follow the :ref:`Lesson Image Requirements <lessonimages>`?
+- Does the lesson appropriately take advantage of Antidote's optional features for content depth (like
+  optional objective verification) or diverse presentations?
+
+Logistics
+---------
+
+- Are any documentation updates also needed?
+- Can we show this in NRE labs? Usage rights?

--- a/docs/hacking/platform.rst
+++ b/docs/hacking/platform.rst
@@ -8,36 +8,75 @@ There are two main components to the Antidote platform:
 - Antidote-web
 - Syringe
 
-In this document, we'll explain what it takes to work on the code.
+In this document, we'll explain what it takes to work on the code. Note that
+this document deals only with the technical steps for getting started working on the various
+Antidote subprojects. Please read the :ref:`platform contribution docs <contrib-platform>`
+for instructions on how to contribute your changes back to the project.
 
 .. _hacking-antidote-web:
 
 Hacking on Antidote-web
 -----------------------
 
-.. NOTE::
+`Antidote-Web <https://github.com/nre-learning/antidote-web>`_ is Antidote's front-end. It is currently written in vanilla Javascript (no framework)
+as well as the expected HTML/CSS stuff. It's also currently packaged with parts of the Apache guacamole
+project, which is why you'll see it commonly deployed on Tomcat. This is something we're working on breaking
+up a bit later.
 
-    This section discusses technical steps for building Antidote-web yourself when working on the code. See
-    :ref:`here <contrib-platform>` for instructions on how to contribute your changes back to the project.
+To preview changes to Antidote-web, the project repo has a Makefile that can be used to build a test Docker container
+that runs your local copy of Antidote-web as a standalone entity, with some mock data. Once in the Antidote-web
+repository, simply run:
 
-Antidote-web is a Web application mainly coded in Javascript coupled to
-elements of the Apache Guacamole project.
-         
-Detailed instructions are WIP - coming soon! In the meantime, just know there is a Makefile in this repository
-and you can run ``make`` to rebuild the Docker container for `antidote-web`.
+.. CODE::
+
+    make test
+
+This may take a few minutes the first time, but eventually you'll have a few containers running in Docker:
+
+.. CODE::
+
+    ~$ docker ps                                                                                                                                                                                            [22:15:00]
+
+    CONTAINER ID        IMAGE                       COMMAND                  CREATED             STATUS              PORTS                    NAMES
+    b13bf8a3aa63        antidotelabs/antidote-web   "/opt/guacamole/bin/…"   2 seconds ago       Up 1 second         0.0.0.0:8080->8080/tcp   aweb
+    c17a8dce40d2        guacamole/guacd             "/bin/sh -c '/usr/lo…"   2 seconds ago       Up 1 second         0.0.0.0:4822->4822/tcp   guacd
+    6e825b629bc6        antidotelabs/utility        "/usr/sbin/sshd -D"      3 seconds ago       Up 2 seconds        0.0.0.0:2222->22/tcp     linux1
+
+You'll be able to access the Web UI at `http://localhost:8080 <http://localhost:8080>`_ now. Re-run ``make test``
+every time you wish to rebuild the environment to incorporate changes.
 
 .. _hacking-syringe:
 
 Hacking on Syringe
 ------------------
 
-.. NOTE::
+`Syringe <https://github.com/nre-learning/syringe>`_ is an application written in Go which provides orchestration for lesson resources on
+Kubernetes, while providing an API for the web front-end to consume.
 
-    This section discusses technical steps for building Syringe yourself when working on the code. See
-    :ref:`here <contrib-platform>` for instructions on how to contribute your changes back to the project.
+To build Syringe, you'll need to install the version of Go specified in `Syringe's Dockerfile <https://github.com/nre-learning/syringe/blob/master/Dockerfile#L1>`_.
+Whatever version of Go is used there, is the currently/officially supported version.
 
-Syringe is mainly an application written in Go which provides orchestration for lesson resources on Kubernetes, while providing an API for the web front-end to consume.
-         
-Detailed instructions are WIP - coming soon! In the meantime, just know there is a Makefile in this repository
-and you can run ``make docker`` to rebuild the Docker container for Syringe, or simply ``make`` to compile from
-source. You can also run ``make test`` to run the unit tests for the project.
+Once done, enter the Syringe repository. There are a few things you can do here. To simply compile Syringe
+binaries, including ``syrctl`` and all of the server-side binaries, run:
+
+.. CODE::
+
+    make
+
+You can also execute Syringe's tests with:
+
+.. CODE::
+
+    make test
+
+This is the same command executed by the CI pipeline, so this is a good way to know if your tests will
+pass before actually pushing anything.
+
+You can also build Syringe's docker container with:
+
+.. CODE::
+
+    make docker
+
+This includes a ``docker push`` step, so if you want to push this image to your own repository
+for testing, you'll need to edit the push target.

--- a/docs/releases/releaseplanning_platform.rst
+++ b/docs/releases/releaseplanning_platform.rst
@@ -19,8 +19,8 @@ information on progress.
 In this first kickoff, we'll begin gathering ideas for things we want to get done in this release.
 These will be retrieved from various sources:
 
-- First we start with the miniprojects and the v1.0 timeline. Are there any milestones for the
-  upcoming release we need to hit?
+- First we start with the `Antidote v1.0 Roadmap <https://github.com/nre-learning/proposals/blob/master/antidote-v1.0/roadmap.md>`_.
+  Are there any milestones for the upcoming release we need to hit?
 - Second, we comb through the issues for the repos and triage accordingly. Which are ready to
   be worked on, or are most imminent, according to complexity labels?
 


### PR DESCRIPTION
Originally I opened this PR to add a dedicated guide for curriculum reviewers to follow. But then I got distracted and also added a few other things.

# Summary

- Curriculum reviewer standards documentation
- Updated platform hacking guides
- Added explanation of when a platform dev blueprint is needed.