### PR TITLE
Updated Youtube link, removed Trello

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -15,7 +15,7 @@ Weekly Standups
 We hold weekly standups - open to all - every Tuesday at 8AM Pacific. Attending these are the best way
 to start getting involved with the project, provide feedback, or ask a question.
 
-All standups are recorded and `published to YouTube <https://www.youtube.com/channel/UCbfZq3sDGx6gmv7KRrhRh4g>`_
+All standups are recorded and `published to YouTube <https://www.youtube.com/c/NRELabs`_
 - usually within a day or two. Standup agendas are usually posted in advance to the
 `Weekly Standup <https://community.networkreliability.engineering/c/weekly-standup>`_ forum topic. Meeting
 minutes will be posted to the same topic after the meeting, with a link to the YouTube video.
@@ -93,7 +93,7 @@ deep into a topic, other weeks we might just casually chat about what's next on 
 Check out our `Twitch channel <https://twitch.tv/nrelabs>`_ to watch live, and interact with us in the chat. Ask questions or
 provide feedback to us live, and we might talk about it on stream!
 
-If you can't join live, check out our `YouTube channel <https://www.youtube.com/channel/UCbfZq3sDGx6gmv7KRrhRh4g>`_, where we post the
+If you can't join live, check out our `YouTube channel <https://www.youtube.com/c/NRELabs`_, where we post the
 recordings for all our streams, as well as all other video content.
 
 Blog
@@ -103,7 +103,3 @@ and any big changes to NRE Labs. You may also be interested to know that this bl
 `maintained in Github <https://github.com/nre-learning/nre-blog>`_, so if you want to write a guest post by opening a pull request
 to that repo, we'd love to have you!
 
-Trello Board
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For slightly less technical project planning around the Antidote community, see our `Trello Board <https://trello.com/b/QdT69weT/nre-labs>`_.
-This is where we plan anything that doesn't fit neatly into a platform release plan, which we manage in Github projects.


### PR DESCRIPTION
Updated Youtube links in "Community Resources" page to point to custom URL.  Removed Trello reference since we don't use Trello.